### PR TITLE
Use npm ci for reproducible CI installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install worker deps
         working-directory: worker
-        run: npm install --legacy-peer-deps
+        run: npm ci
 
       - name: Type-check worker
         working-directory: worker
@@ -54,7 +54,7 @@ jobs:
           node-version: 20
 
       - name: Install frontend deps
-        run: npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
 
       - name: Type-check frontend
         run: npm run type-check

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install worker deps
         working-directory: worker
-        run: npm install --legacy-peer-deps
+        run: npm ci
 
       - name: Type-check worker
         working-directory: worker
@@ -48,7 +48,7 @@ jobs:
           node-version: 20
 
       - name: Install frontend deps
-        run: npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
 
       - name: Type-check frontend
         run: npm run type-check


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses review feedback from PR #14 — replace non-deterministic `npm install` with lockfile-based `npm ci` in CI workflows.

### Changes

**`staging.yml` and `release.yml`** (4 install steps total):

| Step | Before | After | Rationale |
|---|---|---|---|
| Worker install (×2) | `npm install --legacy-peer-deps` | `npm ci` | Worker has no peer dep conflicts; `npm ci` uses lockfile for deterministic installs |
| Frontend install (×2) | `npm install --legacy-peer-deps` | `npm ci --legacy-peer-deps` | `--legacy-peer-deps` still required — `vite-plugin-pwa@1.x` peer dep doesn't cover `vite@8` |

### Verification

Tested both commands locally against the committed lockfiles:
- `npm ci` in `worker/` — installs 63 packages successfully
- `npm ci --legacy-peer-deps` at root — installs 347 packages successfully
- `cd worker && npm run type-check` — passes cleanly after `npm ci`

### Note on `--legacy-peer-deps`

The frontend cannot drop `--legacy-peer-deps` until either:
- `vite-plugin-pwa` releases a version with `vite@8` in its peer dep range, or
- The project downgrades to `vite@7`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3684c3c-dd09-480e-8686-926e1c222195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3684c3c-dd09-480e-8686-926e1c222195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

