### PR TITLE
Fix wrangler-action install failure from frontend peer deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
           wranglerVersion: latest
           apiToken:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command:   pages deploy dist --project-name=vibecoded-stocard --branch=main
+          workingDirectory: worker
+          command:   pages deploy ../dist --project-name=vibecoded-stocard --branch=main
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -64,5 +64,6 @@ jobs:
           wranglerVersion: latest
           apiToken:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: worker
           # Deploys to the staging Pages project (separate from production)
-          command:   pages deploy dist --project-name=cardex-staging
+          command:   pages deploy ../dist --project-name=cardex-staging


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update both staging and release workflows so Cloudflare Pages deploy steps run `wrangler-action` from `worker/`
- change Pages deploy paths from `dist` to `../dist` to keep deploy input unchanged while avoiding root-level `npm i wrangler@latest`
- this prevents `wrangler-action` from hitting the root Vite peer-dependency conflict (`vite-plugin-pwa` vs Vite 8) without changing any package versions

## Testing
- validated workflow YAML parses successfully with Python
- reviewed workflow diff to confirm only wrangler-action execution context/path were changed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54077c74-a3ef-4f3c-ab63-76deb092593d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54077c74-a3ef-4f3c-ab63-76deb092593d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

