### PR TITLE
fix(auth): resilient magic-link verify for Safari / PWA

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -34,6 +34,37 @@ export const authLoginBegin     = ()                  => request<{ options: Publ
 export const authLoginFinish    = (body: unknown)    => request<AuthResponse>('/auth/login/finish',    'POST', body);
 export const authMagicSend      = (email: string)    => request<{ ok: boolean; error?: string }>('/auth/magic/send',   'POST', { email });
 export const authMagicVerify    = (token: string)    => request<AuthResponse>('/auth/magic/verify', 'POST', { token });
+
+/** Magic verify with HTTP status — used for Safari / PWA retry logic (do not strip ?magic= until success). */
+export type MagicVerifyRequestResult =
+  | { status: 'ok'; data: AuthResponse }
+  | { status: 'fail'; transient: boolean; error?: string };
+
+export async function authMagicVerifyRequest(token: string): Promise<MagicVerifyRequestResult> {
+  try {
+    const res = await fetch(`${API_BASE}/auth/magic/verify`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ token }),
+    });
+    let data: AuthResponse & { error?: string } = { token: '', userId: '', username: '' };
+    try {
+      data = (await res.json()) as AuthResponse & { error?: string };
+    } catch {
+      return { status: 'fail', transient: res.status >= 500 || res.status === 0 };
+    }
+    if (res.ok && data.token && data.userId) {
+      return {
+        status: 'ok',
+        data:   { token: data.token, userId: data.userId, username: data.username },
+      };
+    }
+    const transient = res.status >= 500 || res.status === 429 || res.status === 408;
+    return { status: 'fail', transient, error: data.error };
+  } catch {
+    return { status: 'fail', transient: true };
+  }
+}
 export const authMe             = ()                  => request<{ id: string; username: string; email: string }>('/auth/me', 'GET');
 
 // ── Cards ─────────────────────────────────────────────────────────────────────

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,7 +51,9 @@ export async function authMagicVerifyRequest(token: string): Promise<MagicVerify
     try {
       data = (await res.json()) as AuthResponse & { error?: string };
     } catch {
-      return { status: 'fail', transient: res.status >= 500 || res.status === 0 };
+      const transient =
+        res.status >= 500 || res.status === 0 || res.status === 429 || res.status === 408;
+      return { status: 'fail', transient };
     }
     if (res.ok && data.token && data.userId) {
       return {

--- a/src/api.ts
+++ b/src/api.ts
@@ -47,7 +47,7 @@ export async function authMagicVerifyRequest(token: string): Promise<MagicVerify
       headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify({ token }),
     });
-    let data: AuthResponse & { error?: string } = { token: '', userId: '', username: '' };
+    let data: AuthResponse & { error?: string };
     try {
       data = (await res.json()) as AuthResponse & { error?: string };
     } catch {

--- a/src/auth/magic.ts
+++ b/src/auth/magic.ts
@@ -1,5 +1,8 @@
-import { authMagicSend, authMagicVerify } from '../api.js';
-import type { AuthResponse }              from '../types.js';
+import { authMagicSend, authMagicVerify, authMagicVerifyRequest } from '../api.js';
+import type { AuthResponse }                                      from '../types.js';
+
+const MAGIC_VERIFY_ATTEMPTS = 6;
+const MAGIC_VERIFY_BASE_MS  = 280;
 
 export async function sendMagicLink(email: string): Promise<{ ok: boolean; error?: string }> {
   return authMagicSend(email);
@@ -9,15 +12,50 @@ export async function verifyMagicToken(token: string): Promise<AuthResponse> {
   return authMagicVerify(token);
 }
 
-/** Read ?magic= from the current URL, strip it, return token or null. */
-export function consumeMagicTokenFromUrl(): string | null {
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type MagicVerifyOutcome =
+  | { kind: 'ok'; data: AuthResponse }
+  | { kind: 'fail'; clearUrl: boolean; error: string };
+
+/**
+ * Verify with exponential backoff. Transient failures (network, 5xx) keep the
+ * magic token in the URL so pull-to-refresh or a later load can succeed — important
+ * for Safari tab vs Home Screen web app timing.
+ */
+export async function verifyMagicTokenResilient(token: string): Promise<MagicVerifyOutcome> {
+  for (let attempt = 0; attempt < MAGIC_VERIFY_ATTEMPTS; attempt++) {
+    const r = await authMagicVerifyRequest(token);
+    if (r.status === 'ok') return { kind: 'ok', data: r.data };
+    if (!r.transient) {
+      return { kind: 'fail', clearUrl: true, error: r.error ?? 'Verification failed' };
+    }
+    if (attempt < MAGIC_VERIFY_ATTEMPTS - 1) {
+      await delay(MAGIC_VERIFY_BASE_MS * 2 ** attempt);
+    }
+  }
+  return {
+    kind:     'fail',
+    clearUrl: false,
+    error:
+      'Could not reach the server. Refresh the page to try again — your sign-in link is still in the address bar.',
+  };
+}
+
+/** Read ?magic= without removing it (caller clears after success or definitive failure). */
+export function peekMagicTokenFromUrl(): string | null {
   const params = new URLSearchParams(window.location.search);
-  const token  = params.get('magic');
-  if (!token) return null;
+  return params.get('magic');
+}
 
-  // Remove token from URL immediately so refresh doesn't re-attempt
-  const clean = window.location.origin + window.location.pathname;
-  window.history.replaceState({}, '', clean);
-
-  return token;
+/** Remove ?magic= from the address bar after a finished sign-in attempt. */
+export function clearMagicTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('magic')) return;
+  params.delete('magic');
+  const qs   = params.toString();
+  const path = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+  window.history.replaceState({}, '', `${window.location.origin}${path}`);
 }

--- a/src/ui/auth.ts
+++ b/src/ui/auth.ts
@@ -1,6 +1,11 @@
 import { registerWithPasskey }          from '../auth/passkey.js';
 import { loginWithPasskey }             from '../auth/passkey.js';
-import { sendMagicLink, verifyMagicToken, consumeMagicTokenFromUrl } from '../auth/magic.js';
+import {
+  sendMagicLink,
+  verifyMagicTokenResilient,
+  peekMagicTokenFromUrl,
+  clearMagicTokenFromUrl,
+} from '../auth/magic.js';
 import { saveSession, clearSession }   from '../auth/session.js';
 import type { AuthResponse }           from '../types.js';
 
@@ -136,23 +141,25 @@ export async function handleMagicSend(): Promise<void> {
 // ── Magic link verify (called on page load if ?magic= present) ────────────────
 
 export async function handleMagicVerify(): Promise<AuthResponse | null> {
-  const token = consumeMagicTokenFromUrl();
+  const token = peekMagicTokenFromUrl();
   if (!token) return null;
 
   showVerifyingScreen();
   try {
-    const result = await verifyMagicToken(token);
-    if (result.error) {
+    const outcome = await verifyMagicTokenResilient(token);
+    if (outcome.kind === 'fail') {
       showAuthScreen();
       showPanel('magic');
-      showAuthError('magic',
-        result.error === 'Link expired or already used'
+      const msg =
+        outcome.error === 'Link expired or already used' || outcome.error === 'Link expired'
           ? 'This link has expired or was already used. Please request a new one.'
-          : result.error,
-      );
+          : outcome.error;
+      showAuthError('magic', msg);
+      if (outcome.clearUrl) clearMagicTokenFromUrl();
       return null;
     }
-    return result;
+    clearMagicTokenFromUrl();
+    return outcome.data;
   } catch {
     showAuthScreen();
     showPanel('magic');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Safari’s installed web app and the Safari browser tab do not share the same storage. Cardex already stores the JWT in `localStorage`, so logging in in one context cannot populate the other without a larger architectural change.

This PR improves the **magic-link** path, which is where premature URL handling made transient failures much worse than they needed to be.

## What changed

1. **Do not remove `?magic=` until verification succeeds**  
   Previously the app stripped the query string immediately, so any failed verify (network blip, slow first paint, etc.) left the user with no way to retry except requesting a new email. Refresh could not help.

2. **Exponential backoff on `/auth/magic/verify`**  
   Up to 6 attempts with backoff for transient outcomes (fetch errors, HTTP 5xx, 429, 408).

3. **Structured “clear URL or not”**  
   After exhausting retries on transient errors, the magic token stays in the URL so **pull-to-refresh** (or another reload) can try again—matching the “eventually works after refreshes” behavior, but without wasting the one-time token on the first flaky response.

Definitive failures (expired / already used / 4xx) still clear `?magic=` so users are not stuck in a retry loop with a dead token.

## Limits

- Passkey sign-in and passwordless flows that never touch `?magic=` are unchanged; users should still complete passkey registration **inside** the same client (browser vs Home Screen app) they intend to use.
- There is still no way to “copy” a `localStorage` session from Safari into a standalone web app without server-mediated handoff (future work if desired).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75435d82-574a-43cd-b54a-77e9314665fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75435d82-574a-43cd-b54a-77e9314665fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magic-link verification now retries automatically for transient network or service issues, improving success rates.
  * URL magic-token handling is non-destructive: tokens are read without immediate removal and can be cleared explicitly to preserve navigation state.

* **Bug Fixes / UX**
  * Verification flow clears tokens consistently on success and shows clearer, specific messages for expired/used links and other failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tojemoc/cardex/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->