### PR TITLE
feat(auth): pair passkeys with existing account and manage them

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
     <!-- Register -->
     <div class="auth-card" id="auth-register-panel" style="display:none">
-      <div><h2>Create account</h2><p>Enter your email to register a passkey. Your email links passkey and magic link to the same account.</p></div>
+      <div><h2>Create account</h2><p>Enter your email to register a passkey. The same email always maps to one account (including magic link). After sign-in, you can add more passkeys from your profile.</p></div>
       <div class="auth-error" id="register-error"></div>
       <input class="auth-input" type="email" id="reg-email" placeholder="your@email.com" autocomplete="email" />
       <button class="passkey-btn" id="register-btn">
@@ -247,6 +247,12 @@
     <div class="account-info">
       <div class="account-avatar-lg" id="account-avatar">?</div>
       <div><div class="account-name" id="account-name">…</div></div>
+    </div>
+    <div class="account-passkeys">
+      <div class="account-passkeys-head">Passkeys</div>
+      <p class="account-passkeys-hint">Passkeys listed here can sign in to this account. Add one on each device you use.</p>
+      <div id="passkeys-list" class="passkeys-list"></div>
+      <button type="button" class="account-menu-item" id="add-passkey-btn"><span class="item-icon">➕</span><span>Add passkey on this device</span></button>
     </div>
     <div class="account-menu">
       <button class="account-menu-item" id="sign-out-btn" style="color:var(--danger)"><span class="item-icon">🚪</span><span>Sign out</span></button>

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Card, Tombstone, AuthResponse } from './types.js';
+import type { Card, Tombstone, AuthResponse, PasskeyMeta } from './types.js';
 
 // ⚠️  Set this to your deployed Worker URL
 export const API_BASE = (import.meta.env.VITE_API_URL ?? 'http://localhost:8787').replace(/\/$/, '');
@@ -28,13 +28,22 @@ async function request<T>(
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
 
-export const authRegisterBegin  = (email: string)    => request<{ options: PublicKeyCredentialCreationOptionsJSON }>('/auth/register/begin',  'POST', { email });
+/** Omit `email` when signed in to add a passkey to the current account. */
+export const authRegisterBegin = (email?: string) =>
+  request<{ options: PublicKeyCredentialCreationOptionsJSON; error?: string }>(
+    '/auth/register/begin',
+    'POST',
+    email !== undefined ? { email } : {},
+  );
 export const authRegisterFinish = (body: unknown)    => request<AuthResponse>('/auth/register/finish', 'POST', body);
 export const authLoginBegin     = ()                  => request<{ options: PublicKeyCredentialRequestOptionsJSON  }>('/auth/login/begin',     'POST', {});
 export const authLoginFinish    = (body: unknown)    => request<AuthResponse>('/auth/login/finish',    'POST', body);
 export const authMagicSend      = (email: string)    => request<{ ok: boolean; error?: string }>('/auth/magic/send',   'POST', { email });
 export const authMagicVerify    = (token: string)    => request<AuthResponse>('/auth/magic/verify', 'POST', { token });
 export const authMe             = ()                  => request<{ id: string; username: string; email: string }>('/auth/me', 'GET');
+export const authPasskeysList   = ()                  => request<{ passkeys: PasskeyMeta[]; error?: string }>('/auth/passkeys', 'GET');
+export const authPasskeyDelete  = (id: string)      =>
+  request<{ ok?: boolean; error?: string }>(`/auth/passkeys?id=${encodeURIComponent(id)}`, 'DELETE');
 
 // ── Cards ─────────────────────────────────────────────────────────────────────
 

--- a/src/auth/passkey.ts
+++ b/src/auth/passkey.ts
@@ -24,7 +24,8 @@ function b64urlDecode(s: string): ArrayBuffer {
 
 // ── Register ──────────────────────────────────────────────────────────────────
 
-export async function registerWithPasskey(email: string): Promise<AuthResponse> {
+/** Pass `email` on the sign-up screen; omit when signed in to pair another passkey. */
+export async function registerWithPasskey(email?: string): Promise<AuthResponse> {
   const { options, error } = await authRegisterBegin(email) as { options?: any; error?: string };
   if (error || !options) throw new Error(error ?? 'Registration failed');
 
@@ -36,7 +37,7 @@ export async function registerWithPasskey(email: string): Promise<AuthResponse> 
     },
   }) as PublicKeyCredential & { response: AuthenticatorAttestationResponse };
 
-  return authRegisterFinish({
+  const out = await authRegisterFinish({
     challengeToken: options.challenge,
     credential: {
       id:   cred.id,
@@ -48,6 +49,8 @@ export async function registerWithPasskey(email: string): Promise<AuthResponse> 
       },
     },
   });
+  if (out.error || !out.token) throw new Error(out.error ?? 'Registration failed');
+  return out;
 }
 
 // ── Login ─────────────────────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,11 @@ import {
   closeOnBackdrop, showPage, toggleSearch, switchBarcodeView,
 } from './ui/cards.js';
 import { showToast }                from './ui/toast.js';
+import {
+  refreshAccountPasskeys,
+  handleAccountAddPasskey,
+  handleAccountRemovePasskey,
+} from './ui/account-passkeys.js';
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────
 
@@ -95,8 +100,15 @@ function wire(): void {
   });
 
   // Account / sign out
-  on('user-pill',    'click', () => openSheet('account-overlay'));
-  on('account-avatar','click',() => openSheet('account-overlay'));
+  on('user-pill',     'click', () => {
+    openSheet('account-overlay');
+    void refreshAccountPasskeys();
+  });
+  on('account-avatar', 'click', () => {
+    openSheet('account-overlay');
+    void refreshAccountPasskeys();
+  });
+  on('add-passkey-btn', 'click', () => void handleAccountAddPasskey());
   on('sign-out-btn', 'click', () => {
     if (!confirm('Sign out?')) return;
     clearSession();
@@ -136,6 +148,14 @@ function wire(): void {
       const target = btn.dataset['closeSheet'];
       if (target) closeSheet(target);
     });
+  });
+
+  document.getElementById('passkeys-list')?.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest('button[data-cred-id]') as HTMLButtonElement | null;
+    const id  = btn?.dataset.credId;
+    if (!id) return;
+    e.preventDefault();
+    void handleAccountRemovePasskey(id);
   });
 
   // Category chips

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -497,6 +497,38 @@ html, body {
 .account-name { font-size: 18px; font-weight: 700; }
 .account-sub  { font-size: 12px; color: var(--muted); margin-top: 2px; }
 
+.account-passkeys {
+  padding: 0 20px 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.account-passkeys-head {
+  font-size: 12px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--muted); margin-bottom: 6px;
+}
+.account-passkeys-hint {
+  font-size: 12px; color: var(--muted); line-height: 1.45; margin-bottom: 12px;
+}
+.passkeys-list { margin-bottom: 8px; min-height: 24px; }
+.passkeys-empty, .passkeys-error {
+  font-size: 13px; color: var(--muted); padding: 4px 0 8px;
+}
+.passkeys-error { color: var(--danger); }
+.passkeys-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 10px 12px; margin-bottom: 6px; background: var(--card-bg);
+  border-radius: var(--radius-sm); border: 1px solid var(--border);
+}
+.passkeys-row-text { min-width: 0; flex: 1; }
+.passkeys-row-title { font-size: 14px; font-weight: 500; }
+.passkeys-row-sub  { font-size: 11px; color: var(--muted); margin-top: 2px; word-break: break-word; }
+.passkeys-remove-btn {
+  flex-shrink: 0; font-size: 13px; padding: 8px 12px; border-radius: 8px;
+  border: 1px solid var(--border); background: transparent; color: var(--muted);
+  cursor: pointer; font-family: var(--font-body);
+}
+.passkeys-remove-btn:active { opacity: 0.7; }
+
 .account-menu { padding: 8px 20px 0; }
 .account-menu-item {
   display: flex; align-items: center; gap: 14px; padding: 16px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -521,7 +521,7 @@ html, body {
 }
 .passkeys-row-text { min-width: 0; flex: 1; }
 .passkeys-row-title { font-size: 14px; font-weight: 500; }
-.passkeys-row-sub  { font-size: 11px; color: var(--muted); margin-top: 2px; word-break: break-word; }
+.passkeys-row-sub  { font-size: 11px; color: var(--muted); margin-top: 2px; overflow-wrap: break-word; }
 .passkeys-remove-btn {
   flex-shrink: 0; font-size: 13px; padding: 8px 12px; border-radius: 8px;
   border: 1px solid var(--border); background: transparent; color: var(--muted);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,12 @@ export interface Tombstone {
   deletedAt: string; // ISO timestamp
 }
 
+export interface PasskeyMeta {
+  id:         string;
+  createdAt:  string;
+  transports: string[];
+}
+
 export interface Session {
   token:    string;
   userId:   string;

--- a/src/ui/account-passkeys.ts
+++ b/src/ui/account-passkeys.ts
@@ -1,0 +1,105 @@
+import { authPasskeysList, authPasskeyDelete } from '../api.js';
+import { registerWithPasskey }                 from '../auth/passkey.js';
+import { saveSession, getSession }             from '../auth/session.js';
+import { showToast }                           from './toast.js';
+import type { PasskeyMeta }                    from '../types.js';
+
+export async function refreshAccountPasskeys(): Promise<void> {
+  const listEl = document.getElementById('passkeys-list');
+  if (!listEl) return;
+
+  const { passkeys, error } = await authPasskeysList();
+  if (error) {
+    listEl.replaceChildren();
+    const p = document.createElement('p');
+    p.className = 'passkeys-error';
+    p.textContent = error;
+    listEl.appendChild(p);
+    return;
+  }
+  renderPasskeysList(passkeys ?? []);
+}
+
+function renderPasskeysList(items: PasskeyMeta[]): void {
+  const el = document.getElementById('passkeys-list');
+  if (!el) return;
+  el.replaceChildren();
+
+  if (items.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'passkeys-empty';
+    p.textContent = 'No passkeys yet. Add one to sign in with biometrics on this or another device.';
+    el.appendChild(p);
+    return;
+  }
+
+  for (const pk of items) {
+    const row = document.createElement('div');
+    row.className = 'passkeys-row';
+
+    const left = document.createElement('div');
+    left.className = 'passkeys-row-text';
+    const dateStr = new Date(pk.createdAt).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+    const title = document.createElement('div');
+    title.className = 'passkeys-row-title';
+    title.textContent = `Added ${dateStr}`;
+    left.appendChild(title);
+    if (pk.transports?.length) {
+      const sub = document.createElement('div');
+      sub.className = 'passkeys-row-sub';
+      sub.textContent = pk.transports.join(', ');
+      left.appendChild(sub);
+    }
+
+    const rm = document.createElement('button');
+    rm.type            = 'button';
+    rm.className       = 'passkeys-remove-btn';
+    rm.textContent     = 'Remove';
+    rm.dataset.credId = pk.id;
+
+    row.append(left, rm);
+    el.appendChild(row);
+  }
+}
+
+export async function handleAccountAddPasskey(): Promise<void> {
+  if (!getSession()) return;
+  const btn = document.getElementById('add-passkey-btn') as HTMLButtonElement | null;
+  const prev = btn?.textContent;
+  if (btn) {
+    btn.disabled    = true;
+    btn.textContent = 'Follow the prompt…';
+  }
+  try {
+    const result = await registerWithPasskey();
+    if (result.error || !result.token) {
+      showToast(result.error ?? 'Could not add passkey');
+      return;
+    }
+    saveSession(result);
+    await refreshAccountPasskeys();
+    showToast('Passkey added');
+  } catch (e) {
+    const err = e as Error;
+    showToast(err.name === 'NotAllowedError' ? 'Cancelled' : err.message);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      if (prev) btn.textContent = prev;
+    }
+  }
+}
+
+export async function handleAccountRemovePasskey(credId: string): Promise<void> {
+  if (!confirm('Remove this passkey? You can register it again on that device later.')) return;
+  const { ok, error } = await authPasskeyDelete(credId);
+  if (!ok || error) {
+    showToast(error ?? 'Could not remove passkey');
+    return;
+  }
+  await refreshAccountPasskeys();
+  showToast('Passkey removed');
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,7 +57,12 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: (id) => {
-          if (id.includes('src/auth/passkey.ts') || id.includes('src/auth/magic.ts') || id.includes('src/auth/session.ts')) {
+          if (
+            id.includes('src/auth/passkey.ts') ||
+            id.includes('src/auth/magic.ts') ||
+            id.includes('src/auth/session.ts') ||
+            id.includes('src/ui/account-passkeys.ts')
+          ) {
             return 'auth';
           }
           if (id.includes('src/cards/store.ts') || id.includes('src/cards/sync.ts') || id.includes('src/cards/merge.ts')) {

--- a/worker/src/auth/passkey.ts
+++ b/worker/src/auth/passkey.ts
@@ -1,9 +1,12 @@
-import type { Env }                     from '../types.js';
+import type { Env, PasskeyMeta, User }  from '../types.js';
 import { jsonResponse }                 from '../lib/http.js';
 import { generateRandomToken, base64urlDecode, bufferToBase64url, concat } from '../lib/encoding.js';
 import { parseAttestationObject, parseAuthenticatorData, verifyCoseSignature, sha256 } from '../lib/cose.js';
-import { getAndDeleteChallenge, putChallenge, getCredential, putCredential, getUser, upsertUserByEmail } from '../lib/kv.js';
-import { issueToken }                   from './jwt.js';
+import {
+  getAndDeleteChallenge, putChallenge, getCredential, putCredential, getUser, putUser,
+  upsertUserByEmail, deleteCredential,
+} from '../lib/kv.js';
+import { issueToken, verifyToken }      from './jwt.js';
 
 function getRpId(env: Env): string {
   return env.FRONTEND_RP_ID || 'vibecoded-stocard.pages.dev';
@@ -18,15 +21,70 @@ function verifyOrigin(origin: string, env: Env): boolean {
   return allowed.includes(origin);
 }
 
+async function recordPasskeyMeta(
+  env: Env,
+  userId: string,
+  credId: string,
+  transports: string[],
+): Promise<void> {
+  const user = await getUser(env, userId);
+  if (!user) return;
+  const meta: PasskeyMeta = { id: credId, createdAt: new Date().toISOString(), transports };
+  const list = [...(user.passkeys ?? [])];
+  const i    = list.findIndex((p) => p.id === credId);
+  if (i >= 0) list[i] = meta;
+  else list.push(meta);
+  await putUser(env, { ...user, passkeys: list });
+}
+
+/** Backfill index when an older credential logs in but was never listed on the user row. */
+async function ensurePasskeyMeta(
+  env: Env,
+  userId: string,
+  credId: string,
+  transports: string[],
+): Promise<void> {
+  const user = await getUser(env, userId);
+  if (!user) return;
+  if (user.passkeys?.some((p) => p.id === credId)) return;
+  const list = [
+    ...(user.passkeys ?? []),
+    { id: credId, createdAt: new Date().toISOString(), transports },
+  ];
+  await putUser(env, { ...user, passkeys: list });
+}
+
 // ── Register begin ────────────────────────────────────────────────────────────
 
+/**
+ * Start passkey registration.
+ * - With `Authorization: Bearer <jwt>`: add a passkey to the signed-in account (no body).
+ * - Without JWT: `{ email }` required — same email reuses one account (magic link + passkeys).
+ */
 export async function registerBegin(request: Request, env: Env): Promise<Response> {
-  const body = await request.json<{ email?: string }>();
-  const email = body.email?.toLowerCase().trim();
-  if (!email || !email.includes('@')) return jsonResponse({ error: 'Invalid email' }, 400, env);
+  let userId: string;
+  let email:  string;
+  let user:   User | null;
 
-  const userId    = await upsertUserByEmail(env, email);
-  const user      = await getUser(env, userId);
+  if (/^Bearer\s+\S/i.test(request.headers.get('Authorization') ?? '')) {
+    const { userId: uid, error } = await verifyToken(request, env);
+    if (error || !uid) return jsonResponse({ error: error ?? 'Unauthorized' }, 401, env);
+    userId = uid;
+    user   = await getUser(env, userId);
+    if (!user) return jsonResponse({ error: 'User not found' }, 404, env);
+    email = user.email;
+  } else {
+    let body: { email?: string } = {};
+    try {
+      body = await request.json<{ email?: string }>();
+    } catch { /* empty body */ }
+    const em = body.email?.toLowerCase().trim();
+    if (!em || !em.includes('@')) return jsonResponse({ error: 'Invalid email' }, 400, env);
+    email  = em;
+    userId = await upsertUserByEmail(env, email);
+    user   = await getUser(env, userId);
+  }
+
   const challenge = generateRandomToken();
 
   await putChallenge(env, challenge, { userId, email, type: 'register' });
@@ -83,12 +141,16 @@ export async function registerFinish(request: Request, env: Env): Promise<Respon
 
   const credId = bufferToBase64url(authData.credentialId);
 
+  const transports = credential.response.transports ?? [];
+
   await putCredential(env, credId, {
     userId:        challengeData.userId!,
     publicKeyCose: bufferToBase64url(authData.credentialPublicKey),
     counter:       authData.counter,
-    transports:    credential.response.transports ?? [],
+    transports,
   });
+
+  await recordPasskeyMeta(env, challengeData.userId!, credId, transports);
 
   const user  = await getUser(env, challengeData.userId!);
   const token = await issueToken(challengeData.userId!, env);
@@ -162,7 +224,43 @@ export async function loginFinish(request: Request, env: Env): Promise<Response>
 
   await putCredential(env, credential.id, { ...credEntry, counter: authData.counter });
 
+  await ensurePasskeyMeta(env, credEntry.userId, credential.id, credEntry.transports);
+
   const user  = await getUser(env, credEntry.userId);
   const token = await issueToken(credEntry.userId, env);
   return jsonResponse({ token, userId: credEntry.userId, username: user?.username }, 200, env);
+}
+
+// ── Passkey list / revoke (authenticated) ─────────────────────────────────────
+
+export async function listPasskeys(request: Request, env: Env): Promise<Response> {
+  const { userId, error } = await verifyToken(request, env);
+  if (error || !userId) return jsonResponse({ error: error ?? 'Unauthorized' }, 401, env);
+
+  const user = await getUser(env, userId);
+  if (!user) return jsonResponse({ error: 'User not found' }, 404, env);
+
+  return jsonResponse({ passkeys: user.passkeys ?? [] }, 200, env);
+}
+
+export async function deletePasskey(request: Request, env: Env): Promise<Response> {
+  const { userId, error } = await verifyToken(request, env);
+  if (error || !userId) return jsonResponse({ error: error ?? 'Unauthorized' }, 401, env);
+
+  const credId = new URL(request.url).searchParams.get('id');
+  if (!credId) return jsonResponse({ error: 'Missing credential id' }, 400, env);
+
+  const entry = await getCredential(env, credId);
+  if (!entry) return jsonResponse({ error: 'Credential not found' }, 404, env);
+  if (entry.userId !== userId) return jsonResponse({ error: 'Forbidden' }, 403, env);
+
+  await deleteCredential(env, credId);
+
+  const user = await getUser(env, userId);
+  if (user?.passkeys?.length) {
+    const passkeys = user.passkeys.filter((p) => p.id !== credId);
+    await putUser(env, { ...user, passkeys });
+  }
+
+  return jsonResponse({ ok: true }, 200, env);
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,6 +1,9 @@
 import type { Env }          from './types.js';
 import { corsHeaders, jsonResponse } from './lib/http.js';
-import { registerBegin, registerFinish, loginBegin, loginFinish } from './auth/passkey.js';
+import {
+  registerBegin, registerFinish, loginBegin, loginFinish,
+  listPasskeys, deletePasskey,
+} from './auth/passkey.js';
 import { magicSend, magicVerify }    from './auth/magic.js';
 import { verifyToken }               from './auth/jwt.js';
 import { getCards, setCards }        from './cards.js';
@@ -26,6 +29,8 @@ export default {
       else if (pathname === '/auth/register/finish' && request.method === 'POST') response = await registerFinish(request, env);
       else if (pathname === '/auth/login/begin'     && request.method === 'POST') response = await loginBegin(request, env);
       else if (pathname === '/auth/login/finish'    && request.method === 'POST') response = await loginFinish(request, env);
+      else if (pathname === '/auth/passkeys'       && request.method === 'GET') response = await listPasskeys(request, env);
+      else if (pathname === '/auth/passkeys'       && request.method === 'DELETE') response = await deletePasskey(request, env);
 
       // ── Auth — magic link ───────────────────────────────────────────────────
       else if (pathname === '/auth/magic/send'   && request.method === 'POST') response = await magicSend(request, env);
@@ -37,9 +42,11 @@ export default {
         if (error || !userId) response = jsonResponse({ error: error ?? 'Unauthorized' }, 401, env);
         else {
           const user = await getUser(env, userId);
-          response = user
-            ? jsonResponse(user, 200, env)
-            : jsonResponse({ error: 'User not found' }, 404, env);
+          if (!user) response = jsonResponse({ error: 'User not found' }, 404, env);
+          else {
+            const { passkeys: _omitPasskeys, ...publicUser } = user;
+            response = jsonResponse(publicUser, 200, env);
+          }
         }
       }
 

--- a/worker/src/lib/http.ts
+++ b/worker/src/lib/http.ts
@@ -24,7 +24,7 @@ export function corsHeaders(env: Env, requestOrigin?: string): Record<string, st
 
   return {
     'Access-Control-Allow-Origin':  origin,
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Vary': 'Origin',
   };

--- a/worker/src/lib/kv.ts
+++ b/worker/src/lib/kv.ts
@@ -22,6 +22,9 @@ export const getCredential = (env: Env, credId: string) =>
 export const putCredential = (env: Env, credId: string, cred: Credential) =>
   env.CARDEX_KV.put(`cred:${credId}`, JSON.stringify(cred));
 
+export const deleteCredential = (env: Env, credId: string) =>
+  env.CARDEX_KV.delete(`cred:${credId}`);
+
 // ── Challenge ─────────────────────────────────────────────────────────────────
 
 export const putChallenge = (env: Env, token: string, data: ChallengeData) =>

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -1,10 +1,19 @@
 // ── KV value shapes ───────────────────────────────────────────────────────────
 
+/** Stored passkey metadata for listing / removal (credential public key stays under cred:*). */
+export interface PasskeyMeta {
+  id:         string; // WebAuthn credential id (base64url)
+  createdAt:  string; // ISO
+  transports: string[];
+}
+
 export interface User {
   id:        string;
   username:  string;
   email:     string;
   createdAt: string;
+  /** Passkeys registered for this account (backfilled on login when missing). */
+  passkeys?: PasskeyMeta[];
 }
 
 export interface Credential {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users who sign in with a **magic link** (or any session) can now **add a passkey** without re-entering email, see **which passkeys** are on the account, and **remove** ones they no longer trust or use.

Listing passkeys **by email without authentication** is intentionally not exposed (that would be a credential-enumeration / privacy risk). Management is **only for the signed-in user**.

## Backend

- **`POST /auth/register/begin`**: if `Authorization: Bearer <jwt>` is present, starts WebAuthn registration for that user (no JSON body). Without JWT, behaviour is unchanged: `{ email }` required; same email still resolves to one account via `upsertUserByEmail`.
- **`POST /auth/register/finish`**: unchanged contract; after storing `cred:*`, appends metadata to `user.passkeys[]`.
- **`POST /auth/login/finish`**: after a successful assertion, **backfills** `user.passkeys` if this credential was missing (covers accounts created before this index existed).
- **`GET /auth/passkeys`**: returns `{ passkeys: PasskeyMeta[] }` for the JWT subject.
- **`DELETE /auth/passkeys?id=<credentialId>`**: deletes `cred:*` and removes the entry from `user.passkeys` when it belongs to the caller.
- **`GET /auth/me`**: strips `passkeys` from the JSON payload so the field is only returned from the dedicated endpoint.

CORS: `DELETE` allowed on preflight.

## Frontend

- Account sheet (profile): passkey list, **Add passkey on this device**, **Remove** per row.
- Register copy clarifies same-email / magic-link / profile flow.
- `registerWithPasskey()` can be called **without** `email` when the API client already has a bearer token.

## Types

- `PasskeyMeta`: `id`, `createdAt`, `transports` (mirrors worker).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75435d82-574a-43cd-b54a-77e9314665fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75435d82-574a-43cd-b54a-77e9314665fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage passkeys from Account: view all registered passkeys with creation dates and transport details.
  * Add a passkey on the current device after signing in; remove existing passkeys as needed.
  * Registration copy updated: clarifies that the same email maps to one account (including magic link) and additional passkeys can be added post-sign-in.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tojemoc/cardex/pull/29)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->