### PR TITLE
Fix iOS barcode scanning with WASM polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "cardex",
       "version": "2.1.4",
+      "dependencies": {
+        "@undecaf/barcode-detector-polyfill": "^0.9.23"
+      },
       "devDependencies": {
         "typescript": "^6.0.3",
         "vite": "^8.0.13",
@@ -2488,6 +2491,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@undecaf/barcode-detector-polyfill": {
+      "version": "0.9.23",
+      "resolved": "https://registry.npmjs.org/@undecaf/barcode-detector-polyfill/-/barcode-detector-polyfill-0.9.23.tgz",
+      "integrity": "sha512-qVr7jSUbE5a30X9dByDym2NzsqyH+MFwyFiu4QSHDQMLCImTJj/et7pEcOtGqlL4UB5J6J3d0hK4/5d4MMowYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@undecaf/zbar-wasm": "^0.9.16"
+      }
+    },
+    "node_modules/@undecaf/zbar-wasm": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/@undecaf/zbar-wasm/-/zbar-wasm-0.9.16.tgz",
+      "integrity": "sha512-T5PcT6g+tLScGjR4WmnRErNvfKqEc3kRg2ux14wHmIDNbvNeXa0BkFK19PRK/jb6zGy5NyWtn4ko6KeNuZc/fQ==",
+      "license": "LGPL-2.1+",
+      "dependencies": {
+        "jschardet": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4094,6 +4115,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "license": "LGPL-2.1+",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.3"
+  },
+  "dependencies": {
+    "@undecaf/barcode-detector-polyfill": "^0.9.23"
   }
 }

--- a/src/scanner/scanner.ts
+++ b/src/scanner/scanner.ts
@@ -1,12 +1,9 @@
 /**
- * Camera barcode scanner using the BarcodeDetector API.
+ * Camera barcode scanner.
  *
- * Works on Chrome Android 9+ and Chrome desktop.
- * No fallback library needed — target platform (Android Chrome) has full support.
- *
- * Usage:
- *   const result = await startScan();   // opens overlay, resolves on first scan
- *   // result.value, result.format
+ * Uses native BarcodeDetector on Chrome Android / desktop when reliable.
+ * On iOS, loads a ZBar WASM polyfill — the native API exists but does not decode
+ * live video frames.
  */
 
 export interface ScanResult {
@@ -14,27 +11,27 @@ export interface ScanResult {
   format: string;
 }
 
-// BarcodeDetector is not yet in the standard TypeScript lib, declare it here.
 interface BarcodeDetectorOptions {
   formats?: string[];
 }
 interface DetectedBarcode {
-  rawValue:        string;
-  format:          string;
-  boundingBox:     DOMRectReadOnly;
-  cornerPoints:    { x: number; y: number }[];
+  rawValue:     string;
+  format:       string;
+  boundingBox:  DOMRectReadOnly;
+  cornerPoints: { x: number; y: number }[];
 }
-declare class BarcodeDetector {
-  constructor(options?: BarcodeDetectorOptions);
-  detect(image: ImageBitmapSource): Promise<DetectedBarcode[]>;
-  static getSupportedFormats(): Promise<string[]>;
+interface BarcodeDetectorCtor {
+  new (options?: BarcodeDetectorOptions): {
+    detect(image: ImageBitmapSource): Promise<DetectedBarcode[]>;
+  };
+  getSupportedFormats(): Promise<string[]>;
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-/** Returns true if BarcodeDetector is available in this browser. */
+/** True when this device can open a camera for scanning. */
 export async function isSupported(): Promise<boolean> {
-  return 'BarcodeDetector' in window;
+  return !!navigator.mediaDevices?.getUserMedia;
 }
 
 /**
@@ -66,13 +63,16 @@ export async function startScan(): Promise<ScanResult> {
     const overlay = buildOverlay();
     document.body.appendChild(overlay);
 
-    let animFrame: number | null          = null;
-    let detector:  BarcodeDetector | null = null;
+    let animFrame: number | null = null;
+    let scanTimer: ReturnType<typeof setTimeout> | null = null;
+    let detector:  InstanceType<BarcodeDetectorCtor> | null = null;
+    let scanning = false;
     let done = false;
 
     function cleanup() {
       done = true;
       if (animFrame !== null) cancelAnimationFrame(animFrame);
+      if (scanTimer !== null) clearTimeout(scanTimer);
       stream.getTracks().forEach(t => t.stop());
       overlay.remove();
     }
@@ -85,47 +85,134 @@ export async function startScan(): Promise<ScanResult> {
 
     async function init() {
       try {
-        const formats = await BarcodeDetector.getSupportedFormats();
-        detector = new BarcodeDetector({ formats });
+        const Detector = await resolveDetectorCtor();
+        const formats  = await Detector.getSupportedFormats();
+        detector = new Detector({ formats });
 
         const video = overlay.querySelector<HTMLVideoElement>('#scanner-video')!;
         video.srcObject = stream;
         await video.play();
+        await waitForVideoReady(video);
 
-        scanLoop(video);
+        scheduleScan(video);
       } catch (err) {
         cleanup();
         reject(err);
       }
     }
 
-    function scanLoop(video: HTMLVideoElement) {
+    function scheduleScan(video: HTMLVideoElement) {
       if (done) return;
 
-      animFrame = requestAnimationFrame(async () => {
-        if (done || !detector) return;
+      const intervalMs = usePolyfill() ? 120 : 0;
 
-        try {
-          const results = await detector.detect(video);
-          if (results.length > 0) {
-            const hit = results[0]!;
-            cleanup();
-            resolve({
-              value:  hit.rawValue,
-              format: normaliseFormat(hit.format),
-            });
-            return;
+      const tick = () => {
+        if (done) return;
+        void runScan(video).finally(() => {
+          if (done) return;
+          if (intervalMs > 0) {
+            scanTimer = setTimeout(tick, intervalMs);
+          } else {
+            animFrame = requestAnimationFrame(tick);
           }
-        } catch {
-          // Frame decode errors are normal — keep looping
-        }
+        });
+      };
 
-        scanLoop(video);
-      });
+      tick();
+    }
+
+    async function runScan(video: HTMLVideoElement) {
+      if (done || !detector || scanning) return;
+      if (video.videoWidth === 0 || video.videoHeight === 0) return;
+
+      scanning = true;
+      try {
+        const source  = await frameSource(video);
+        const results = await detector.detect(source);
+        if (results.length > 0) {
+          const hit = results[0]!;
+          cleanup();
+          resolve({
+            value:  hit.rawValue,
+            format: normaliseFormat(hit.format),
+          });
+        }
+      } catch {
+        // Frame decode errors are normal — keep looping
+      } finally {
+        scanning = false;
+      }
     }
 
     init();
   });
+}
+
+// ── Detector selection ────────────────────────────────────────────────────────
+
+let polyfillActive = false;
+
+function usePolyfill(): boolean {
+  return isAppleMobile();
+}
+
+function isAppleMobile(): boolean {
+  const ua = navigator.userAgent;
+  return /iPhone|iPad|iPod/i.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+async function resolveDetectorCtor(): Promise<BarcodeDetectorCtor> {
+  if (!usePolyfill() && 'BarcodeDetector' in window) {
+    try {
+      const native = (window as Window & { BarcodeDetector: BarcodeDetectorCtor }).BarcodeDetector;
+      await native.getSupportedFormats();
+      return native;
+    } catch {
+      // Native API present but unusable — fall through to polyfill
+    }
+  }
+
+  const { BarcodeDetectorPolyfill } = await import('@undecaf/barcode-detector-polyfill');
+  polyfillActive = true;
+  return BarcodeDetectorPolyfill as unknown as BarcodeDetectorCtor;
+}
+
+async function waitForVideoReady(video: HTMLVideoElement): Promise<void> {
+  if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && video.videoWidth > 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new DOMException('Camera preview timed out', 'TimeoutError'));
+    }, 12_000);
+
+    const onReady = () => {
+      if (video.videoWidth === 0) return;
+      clearTimeout(timeout);
+      video.removeEventListener('loadedmetadata', onReady);
+      video.removeEventListener('playing', onReady);
+      resolve();
+    };
+
+    video.addEventListener('loadedmetadata', onReady);
+    video.addEventListener('playing', onReady);
+    onReady();
+  });
+}
+
+async function frameSource(video: HTMLVideoElement): Promise<ImageBitmapSource> {
+  // The WASM polyfill extracts frames from <video> itself (required on iOS).
+  if (polyfillActive || usePolyfill()) {
+    return video;
+  }
+
+  try {
+    return await createImageBitmap(video);
+  } catch {
+    return video;
+  }
 }
 
 // ── Overlay DOM ───────────────────────────────────────────────────────────────

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import { VitePWA }      from 'vite-plugin-pwa';
 import pkg              from './package.json';
 
 export default defineConfig({
+  optimizeDeps: {
+    // WASM polyfill must not be pre-bundled by Vite
+    exclude: ['@undecaf/barcode-detector-polyfill', '@undecaf/zbar-wasm'],
+  },
   define: {
     // Makes __APP_VERSION__ available as a typed string at build time.
     // Usage in TS: declare const __APP_VERSION__: string;  (already in globals.d.ts)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iOS Safari, tapping the scan button opened the camera overlay but never detected a barcode. The UI looked fine; detection simply never fired.

## Root cause

The scanner relied on the native `BarcodeDetector` API. iOS exposes that API, so `isSupported()` returned true and the scan button appeared, but `detect()` on a live `<video>` stream does not return results on iOS (known platform limitation / broken Shape Detection implementation).

## Solution

- **iPhone / iPad:** Dynamically load `@undecaf/barcode-detector-polyfill` (ZBar WASM), which correctly scans live video.
- **Android Chrome / desktop:** Keep using native `BarcodeDetector` when available.
- **Reliability:** Wait for `videoWidth` / `videoHeight` before starting the scan loop; avoid overlapping async `detect()` calls; throttle WASM scans to ~8 fps.

## Testing

Please verify on a physical iPhone:

1. Add card → tap scan → grant camera
2. Point at a loyalty barcode (EAN-13 / Code 128)
3. Confirm number and format populate and toast shows

Android scanning should be unchanged (native path).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9be224-0fe0-479f-8c76-bdd437237cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9be224-0fe0-479f-8c76-bdd437237cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

