### PR TITLE
Fix passkey account takeover and harden WebAuthn for iOS PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,13 @@
 
     <!-- Register -->
     <div class="auth-card" id="auth-register-panel" style="display:none">
-      <div><h2>Create account</h2><p>Enter your email to register a passkey. The same email always maps to one account (including magic link). After sign-in, you can add more passkeys from your profile.</p></div>
+      <div><h2>Create account</h2><p>Enter your email and we'll send a confirmation link. After you verify your email, you'll register a passkey on this device. Already have an account? Sign in first, then add passkeys from your profile.</p></div>
       <div class="auth-error" id="register-error"></div>
+      <div class="auth-success" id="register-success"></div>
       <input class="auth-input" type="email" id="reg-email" placeholder="your@email.com" autocomplete="email" />
       <button class="passkey-btn" id="register-btn">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-        Register Passkey
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="2,4 12,13 22,4"/></svg>
+        Send confirmation email
       </button>
       <div class="auth-divider"><hr/><span>or skip passkey</span><hr/></div>
       <button class="magic-btn" id="show-magic-login-2">
@@ -250,7 +251,7 @@
     </div>
     <div class="account-passkeys">
       <div class="account-passkeys-head">Passkeys</div>
-      <p class="account-passkeys-hint">Passkeys listed here can sign in to this account. Add one on each device you use.</p>
+      <p class="account-passkeys-hint">Passkeys listed here can sign in to this account. Add one on each device you use. Remove any you don't recognize.</p>
       <div id="passkeys-list" class="passkeys-list"></div>
       <button type="button" class="account-menu-item" id="add-passkey-btn"><span class="item-icon">➕</span><span>Add passkey on this device</span></button>
     </div>

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,11 +66,18 @@ export async function authPasskeySetupVerifyRequest(token: string): Promise<Pass
         res.status >= 500 || res.status === 0 || res.status === 429 || res.status === 408;
       return { status: 'fail', transient };
     }
-    if (res.ok && data.setupToken && data.email) {
+    if (
+      res.ok
+      && data
+      && typeof data === 'object'
+      && data.setupToken
+      && data.email
+    ) {
       return { status: 'ok', setupToken: data.setupToken, email: data.email };
     }
     const transient = res.status >= 500 || res.status === 429 || res.status === 408;
-    return { status: 'fail', transient, error: data.error, detail: data.detail };
+    const errBody   = data && typeof data === 'object' ? data : undefined;
+    return { status: 'fail', transient, error: errBody?.error ?? 'Invalid server response', detail: errBody?.detail };
   } catch {
     return { status: 'fail', transient: true };
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,18 +28,53 @@ async function request<T>(
 
 // ── Auth ──────────────────────────────────────────────────────────────────────
 
-/** Omit `email` when signed in to add a passkey to the current account. */
-export const authRegisterBegin = (email?: string) =>
-  request<{ options: PublicKeyCredentialCreationOptionsJSON; error?: string }>(
+/** Signed in: omit body. After email setup verify: pass `setupToken`. */
+export const authRegisterBegin = (setupToken?: string) =>
+  request<{ options: PublicKeyCredentialCreationOptionsJSON; error?: string; detail?: string }>(
     '/auth/register/begin',
     'POST',
-    email !== undefined ? { email } : {},
+    setupToken !== undefined ? { setupToken } : {},
   );
-export const authRegisterFinish = (body: unknown)    => request<AuthResponse>('/auth/register/finish', 'POST', body);
-export const authLoginBegin     = ()                  => request<{ options: PublicKeyCredentialRequestOptionsJSON  }>('/auth/login/begin',     'POST', {});
-export const authLoginFinish    = (body: unknown)    => request<AuthResponse>('/auth/login/finish',    'POST', body);
+export const authRegisterFinish = (body: unknown)    => request<AuthResponse & { error?: string; detail?: string }>('/auth/register/finish', 'POST', body);
+export const authLoginBegin     = ()                  => request<{ options: PublicKeyCredentialRequestOptionsJSON; error?: string }>('/auth/login/begin',     'POST', {});
+export const authLoginFinish    = (body: unknown)    => request<AuthResponse & { error?: string }>('/auth/login/finish',    'POST', body);
 export const authMagicSend      = (email: string)    => request<{ ok: boolean; error?: string }>('/auth/magic/send',   'POST', { email });
-export const authMagicVerify    = (token: string)    => request<AuthResponse>('/auth/magic/verify', 'POST', { token });
+export const authMagicVerify    = (token: string)    => request<AuthResponse & { error?: string }>('/auth/magic/verify', 'POST', { token });
+
+export const authPasskeySetupSend = (email: string) =>
+  request<{ ok?: boolean; error?: string; detail?: string }>('/auth/passkey/setup/send', 'POST', { email });
+export const authPasskeySetupVerify = (token: string) =>
+  request<{ setupToken?: string; email?: string; error?: string; detail?: string }>('/auth/passkey/setup/verify', 'POST', { token });
+
+/** Passkey setup verify with HTTP status — Safari / PWA retry (keep ?passkey-setup= until success). */
+export type PasskeySetupVerifyRequestResult =
+  | { status: 'ok'; setupToken: string; email: string }
+  | { status: 'fail'; transient: boolean; error?: string; detail?: string };
+
+export async function authPasskeySetupVerifyRequest(token: string): Promise<PasskeySetupVerifyRequestResult> {
+  try {
+    const res = await fetch(`${API_BASE}/auth/passkey/setup/verify`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ token }),
+    });
+    let data: { setupToken?: string; email?: string; error?: string; detail?: string };
+    try {
+      data = (await res.json()) as typeof data;
+    } catch {
+      const transient =
+        res.status >= 500 || res.status === 0 || res.status === 429 || res.status === 408;
+      return { status: 'fail', transient };
+    }
+    if (res.ok && data.setupToken && data.email) {
+      return { status: 'ok', setupToken: data.setupToken, email: data.email };
+    }
+    const transient = res.status >= 500 || res.status === 429 || res.status === 408;
+    return { status: 'fail', transient, error: data.error, detail: data.detail };
+  } catch {
+    return { status: 'fail', transient: true };
+  }
+}
 
 /** Magic verify with HTTP status — used for Safari / PWA retry logic (do not strip ?magic= until success). */
 export type MagicVerifyRequestResult =

--- a/src/auth/passkey-setup.ts
+++ b/src/auth/passkey-setup.ts
@@ -1,0 +1,57 @@
+import { authPasskeySetupSend, authPasskeySetupVerifyRequest } from '../api.js';
+
+const SETUP_VERIFY_ATTEMPTS = 6;
+const SETUP_VERIFY_BASE_MS  = 280;
+
+export async function sendPasskeySetupEmail(email: string): Promise<{ ok?: boolean; error?: string; detail?: string }> {
+  return authPasskeySetupSend(email);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type PasskeySetupVerifyOutcome =
+  | { kind: 'ok'; setupToken: string; email: string }
+  | { kind: 'fail'; clearUrl: boolean; error: string };
+
+/**
+ * Verify with exponential backoff. Transient failures keep ?passkey-setup= in the URL
+ * so pull-to-refresh or a later load can succeed — same pattern as magic links on iOS PWA.
+ */
+export async function verifyPasskeySetupTokenResilient(token: string): Promise<PasskeySetupVerifyOutcome> {
+  for (let attempt = 0; attempt < SETUP_VERIFY_ATTEMPTS; attempt++) {
+    const r = await authPasskeySetupVerifyRequest(token);
+    if (r.status === 'ok') return { kind: 'ok', setupToken: r.setupToken, email: r.email };
+    if (!r.transient) {
+      return {
+        kind:     'fail',
+        clearUrl: true,
+        error:    r.detail ?? r.error ?? 'Verification failed',
+      };
+    }
+    if (attempt < SETUP_VERIFY_ATTEMPTS - 1) {
+      await delay(SETUP_VERIFY_BASE_MS * 2 ** attempt);
+    }
+  }
+  return {
+    kind:     'fail',
+    clearUrl: false,
+    error:
+      'Could not reach the server. Refresh the page to try again — your confirmation link is still in the address bar.',
+  };
+}
+
+export function peekPasskeySetupTokenFromUrl(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('passkey-setup');
+}
+
+export function clearPasskeySetupTokenFromUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('passkey-setup')) return;
+  params.delete('passkey-setup');
+  const qs   = params.toString();
+  const path = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+  window.history.replaceState({}, '', `${window.location.origin}${path}`);
+}

--- a/src/auth/passkey.ts
+++ b/src/auth/passkey.ts
@@ -1,6 +1,7 @@
 import {
   authRegisterBegin, authRegisterFinish,
   authLoginBegin,    authLoginFinish,
+  type PublicKeyCredentialCreationOptionsJSON,
 } from '../api.js';
 import type { AuthResponse } from '../types.js';
 
@@ -24,17 +25,21 @@ function b64urlDecode(s: string): ArrayBuffer {
 
 // ── Register ──────────────────────────────────────────────────────────────────
 
-/** Pass `email` on the sign-up screen; omit when signed in to pair another passkey. */
-export async function registerWithPasskey(email?: string): Promise<AuthResponse> {
-  const { options, error } = await authRegisterBegin(email) as { options?: any; error?: string };
-  if (error || !options) throw new Error(error ?? 'Registration failed');
+/** After email setup verify: pass `setupToken`. Omit when signed in to pair another passkey. */
+export async function registerWithPasskey(setupToken?: string): Promise<AuthResponse> {
+  const { options, error, detail } = await authRegisterBegin(setupToken) as {
+    options?: PublicKeyCredentialCreationOptionsJSON;
+    error?: string;
+    detail?: string;
+  };
+  if (error || !options) throw new Error(detail ?? error ?? 'Registration failed');
 
   const cred = await navigator.credentials.create({
     publicKey: {
       ...options,
       challenge: b64urlDecode(options.challenge),
       user: { ...options.user, id: b64urlDecode(options.user.id) },
-    },
+    } as PublicKeyCredentialCreationOptions,
   }) as PublicKeyCredential & { response: AuthenticatorAttestationResponse };
 
   const out = await authRegisterFinish({

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import { loadSession, saveSession, clearSession, getSession } from './auth/sessi
 import { syncOnOpen }                from './cards/sync.js';
 import { loadFromLocalStorage }     from './cards/store.js';
 import {
-  showPanel, showAuthScreen, handleRegister,
-  handleLogin, handleMagicSend, handleMagicVerify,
+  showPanel, showAuthScreen, handleRegisterSendEmail,
+  handleLogin, handleMagicSend, handleMagicVerify, handlePasskeySetupVerify,
 } from './ui/auth.js';
 import {
   renderCards, filterByCategory, openDetail,
@@ -26,7 +26,15 @@ async function init(): Promise<void> {
   buildColorPicker();
   loadFromLocalStorage();
 
-  // 1. Check for ?magic= token first
+  // 1. Check for ?passkey-setup= (email-confirmed registration)
+  const setupResult = await handlePasskeySetupVerify();
+  if (setupResult) {
+    saveSession(setupResult);
+    await bootMainApp();
+    return;
+  }
+
+  // 2. Check for ?magic= token
   const magicResult = await handleMagicVerify();
   if (magicResult) {
     saveSession(magicResult);
@@ -34,14 +42,14 @@ async function init(): Promise<void> {
     return;
   }
 
-  // 2. Restore existing session
+  // 3. Restore existing session
   const session = loadSession();
   if (session) {
     await bootMainApp();
     return;
   }
 
-  // 3. No session — show auth
+  // 4. No session — show auth
   showAuthScreen();
   showPanel('login');
 }
@@ -77,10 +85,7 @@ function wire(): void {
     const r = await handleLogin();
     if (r) { saveSession(r); await bootMainApp(); }
   });
-  on('register-btn',     'click', async () => {
-    const r = await handleRegister();
-    if (r) { saveSession(r); await bootMainApp(); }
-  });
+  on('register-btn',     'click', () => void handleRegisterSendEmail());
   on('magic-btn',        'click', () => handleMagicSend());
   on('show-register',    'click', () => showPanel('register'));
   on('show-login',       'click', () => showPanel('login'));

--- a/src/ui/auth.ts
+++ b/src/ui/auth.ts
@@ -6,6 +6,12 @@ import {
   peekMagicTokenFromUrl,
   clearMagicTokenFromUrl,
 } from '../auth/magic.js';
+import {
+  sendPasskeySetupEmail,
+  verifyPasskeySetupTokenResilient,
+  peekPasskeySetupTokenFromUrl,
+  clearPasskeySetupTokenFromUrl,
+} from '../auth/passkey-setup.js';
 import { saveSession, clearSession }   from '../auth/session.js';
 import type { AuthResponse }           from '../types.js';
 
@@ -26,6 +32,24 @@ export function showPanel(panel: Panel): void {
   if (panel === 'magic') {
     setTimeout(() => document.getElementById('magic-email')?.focus(), 50);
   }
+  if (panel === 'register') {
+    resetRegisterPanel();
+    setTimeout(() => document.getElementById('reg-email')?.focus(), 50);
+  }
+}
+
+function resetRegisterPanel(): void {
+  const emailEl = document.getElementById('reg-email') as HTMLInputElement | null;
+  const btn     = document.getElementById('register-btn') as HTMLButtonElement | null;
+  const success = document.getElementById('register-success');
+  if (emailEl) emailEl.style.display = '';
+  if (btn) {
+    btn.style.display = '';
+    btn.disabled      = false;
+    btn.textContent   = 'Send confirmation email';
+  }
+  success?.classList.remove('show');
+  if (success) success.textContent = '';
 }
 
 // ── Auth screen visibility ────────────────────────────────────────────────────
@@ -36,9 +60,12 @@ export function showAuthScreen(): void {
   document.getElementById('main-app')!.style.display        = 'none';
 }
 
-export function showVerifyingScreen(): void {
+export function showVerifyingScreen(label = 'Signing you in…'): void {
   document.getElementById('auth-screen')!.style.display    = 'none';
-  document.getElementById('magic-verifying')!.style.display = 'flex';
+  const verifying = document.getElementById('magic-verifying')!;
+  verifying.style.display = 'flex';
+  const p = verifying.querySelector('p');
+  if (p) p.textContent = label;
   document.getElementById('main-app')!.style.display        = 'none';
 }
 
@@ -49,7 +76,7 @@ export function showAuthError(panel: Panel, msg: string): void {
   if (!el) return;
   el.textContent = msg;
   el.classList.add('show');
-  setTimeout(() => el.classList.remove('show'), 5000);
+  setTimeout(() => el.classList.remove('show'), 8000);
 }
 
 function showAuthSuccess(panel: Panel, msg: string): void {
@@ -68,25 +95,64 @@ function setLoading(btnId: string, on: boolean, label: string): void {
   btn.textContent = on ? 'Please wait…' : label;
 }
 
-// ── Passkey register ──────────────────────────────────────────────────────────
+// ── Passkey register (email confirmation first) ───────────────────────────────
 
-export async function handleRegister(): Promise<AuthResponse | null> {
+export async function handleRegisterSendEmail(): Promise<void> {
   const email = (document.getElementById('reg-email') as HTMLInputElement).value.trim();
   if (!email || !email.includes('@')) {
     showAuthError('register', 'Please enter a valid email address');
-    return null;
+    return;
   }
-  setLoading('register-btn', true, 'Register Passkey');
+  setLoading('register-btn', true, 'Send confirmation email');
   try {
-    const result = await registerWithPasskey(email);
-    if (result.error) { showAuthError('register', result.error); return null; }
+    const { ok, error, detail } = await sendPasskeySetupEmail(email);
+    if (error === 'ACCOUNT_EXISTS') {
+      showAuthError(
+        'register',
+        detail ?? 'An account with this email already exists. Sign in, then add a passkey from your profile.',
+      );
+      return;
+    }
+    if (error || !ok) {
+      showAuthError('register', detail ?? error ?? 'Could not send email');
+      return;
+    }
+    const emailEl = document.getElementById('reg-email') as HTMLInputElement;
+    const btn     = document.getElementById('register-btn') as HTMLButtonElement;
+    emailEl.style.display = 'none';
+    btn.style.display     = 'none';
+    showAuthSuccess(
+      'register',
+      `✉️ Confirmation link sent to ${email}. Open it on this device to register your passkey. Expires in 15 minutes.`,
+    );
+  } catch {
+    showAuthError('register', 'Could not send email. Check your connection.');
+  } finally {
+    setLoading('register-btn', false, 'Send confirmation email');
+  }
+}
+
+/** After ?passkey-setup= link verify — create passkey and sign in. */
+export async function handlePasskeySetupAndRegister(setupToken: string): Promise<AuthResponse | null> {
+  showVerifyingScreen('Creating your passkey…');
+  try {
+    const result = await registerWithPasskey(setupToken);
+    if (result.error) {
+      showAuthScreen();
+      showPanel('register');
+      showAuthError('register', result.error);
+      return null;
+    }
     return result;
   } catch (e) {
     const err = e as Error;
-    showAuthError('register', err.name === 'NotAllowedError' ? 'Biometric prompt cancelled.' : err.message);
+    showAuthScreen();
+    showPanel('register');
+    showAuthError(
+      'register',
+      err.name === 'NotAllowedError' ? 'Biometric prompt cancelled.' : err.message,
+    );
     return null;
-  } finally {
-    setLoading('register-btn', false, 'Register Passkey');
   }
 }
 
@@ -96,7 +162,13 @@ export async function handleLogin(): Promise<AuthResponse | null> {
   setLoading('login-btn', true, 'Sign in with Passkey');
   try {
     const result = await loginWithPasskey();
-    if (result.error) { showAuthError('login', result.error); return null; }
+    if (result.error) {
+      const msg = result.error === 'Signature verification failed'
+        ? 'Passkey sign-in failed on this device. Try a magic link, or sign in in Safari and add a passkey for this app from your profile.'
+        : result.error;
+      showAuthError('login', msg);
+      return null;
+    }
     return result;
   } catch (e) {
     const err = e as Error;
@@ -164,6 +236,32 @@ export async function handleMagicVerify(): Promise<AuthResponse | null> {
     showAuthScreen();
     showPanel('magic');
     showAuthError('magic', 'Verification failed — please try again.');
+    return null;
+  }
+}
+
+// ── Passkey setup link verify (?passkey-setup=) ───────────────────────────────
+
+export async function handlePasskeySetupVerify(): Promise<AuthResponse | null> {
+  const token = peekPasskeySetupTokenFromUrl();
+  if (!token) return null;
+
+  showVerifyingScreen('Confirming your email…');
+  try {
+    const outcome = await verifyPasskeySetupTokenResilient(token);
+    if (outcome.kind === 'fail') {
+      showAuthScreen();
+      showPanel('register');
+      showAuthError('register', outcome.error);
+      if (outcome.clearUrl) clearPasskeySetupTokenFromUrl();
+      return null;
+    }
+    clearPasskeySetupTokenFromUrl();
+    return handlePasskeySetupAndRegister(outcome.setupToken);
+  } catch {
+    showAuthScreen();
+    showPanel('register');
+    showAuthError('register', 'Verification failed — please try again.');
     return null;
   }
 }

--- a/worker/src/auth/magic.ts
+++ b/worker/src/auth/magic.ts
@@ -3,6 +3,7 @@ import { jsonResponse }          from '../lib/http.js';
 import { generateRandomToken }   from '../lib/encoding.js';
 import { upsertUserByEmail, getUser, putMagicLink, getAndDeleteMagicLink } from '../lib/kv.js';
 import { issueToken }            from './jwt.js';
+import { sendBrevoEmail, requestOrigin, buildMagicEmailHtml } from '../lib/email.js';
 
 const MAGIC_TTL_MS      = 15 * 60 * 1_000; // 15 minutes
 const MAGIC_TTL_SECONDS = 900;
@@ -19,11 +20,8 @@ export async function magicSend(request: Request, env: Env): Promise<Response> {
 
   await putMagicLink(env, token, { userId, email, expires: Date.now() + MAGIC_TTL_MS });
 
-  // Use the request's Origin so the magic link points back to whichever
-  // frontend made the request — works for staging preview URLs too.
-  const requestOrigin = request.headers.get('Origin');
-  const origin        = requestOrigin || env.FRONTEND_ORIGIN || 'https://vibecoded-stocard.pages.dev';
-  const magicUrl      = `${origin}/?magic=${token}`;
+  const origin   = requestOrigin(request, env);
+  const magicUrl = `${origin}/?magic=${token}`;
 
   const result = await sendBrevoEmail({
     apiKey:    env.BREVO_API_KEY,
@@ -31,7 +29,7 @@ export async function magicSend(request: Request, env: Env): Promise<Response> {
     fromEmail: env.EMAIL_FROM      || 'noreply@cardex.app',
     fromName:  env.EMAIL_FROM_NAME || 'Cardex',
     subject:   'Your Cardex sign-in link',
-    html:      buildEmailHtml(magicUrl),
+    html:      buildMagicEmailHtml(magicUrl),
   });
 
   if (!result.ok) {
@@ -59,50 +57,3 @@ export async function magicVerify(request: Request, env: Env): Promise<Response>
   return jsonResponse({ token: jwtToken, userId: data.userId, username: user.username }, 200, env);
 }
 
-// ── Brevo helper ──────────────────────────────────────────────────────────────
-
-interface BrevoOptions {
-  apiKey:    string;
-  to:        string;
-  fromEmail: string;
-  fromName:  string;
-  subject:   string;
-  html:      string;
-}
-
-async function sendBrevoEmail(opts: BrevoOptions): Promise<{ ok: boolean; body: string }> {
-  const res = await fetch('https://api.brevo.com/v3/smtp/email', {
-    method:  'POST',
-    headers: {
-      'api-key':      opts.apiKey,
-      'Content-Type': 'application/json',
-      'Accept':       'application/json',
-    },
-    body: JSON.stringify({
-      sender:      { email: opts.fromEmail, name: opts.fromName },
-      to:          [{ email: opts.to }],
-      subject:     opts.subject,
-      htmlContent: opts.html,
-    }),
-  });
-  return { ok: res.ok, body: await res.text() };
-}
-
-function buildEmailHtml(magicUrl: string): string {
-  return `
-    <div style="font-family:system-ui,sans-serif;max-width:480px;margin:0 auto;padding:32px 24px;background:#f9f9fb;border-radius:12px">
-      <h1 style="font-size:24px;font-weight:700;margin:0 0 8px;color:#0a0a0f">Sign in to Cardex</h1>
-      <p style="color:#555;margin:0 0 28px;line-height:1.6">
-        Click the button below to sign in. This link expires in <strong>15 minutes</strong> and can only be used once.
-      </p>
-      <a href="${magicUrl}"
-         style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#7c6dfa,#fa6d9a);color:white;text-decoration:none;border-radius:10px;font-weight:600;font-size:16px">
-        Sign in to Cardex
-      </a>
-      <p style="color:#999;font-size:12px;margin:28px 0 0;line-height:1.6">
-        If you didn't request this, you can safely ignore this email.<br/>
-        Or copy this link:<br/>
-        <a href="${magicUrl}" style="color:#7c6dfa;word-break:break-all">${magicUrl}</a>
-      </p>
-    </div>`;
-}

--- a/worker/src/auth/passkey-setup.ts
+++ b/worker/src/auth/passkey-setup.ts
@@ -20,7 +20,12 @@ const GRANT_TTL_MS = 10 * 60 * 1_000;
 // ── Send confirmation email (new accounts only) ───────────────────────────────
 
 export async function passkeySetupSend(request: Request, env: Env): Promise<Response> {
-  const body  = await request.json<{ email?: string }>();
+  let body: { email?: string } = {};
+  try {
+    body = await request.json<{ email?: string }>();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400, env);
+  }
   const email = body.email?.toLowerCase().trim();
   if (!email || !email.includes('@')) return jsonResponse({ error: 'Invalid email' }, 400, env);
 
@@ -58,7 +63,13 @@ export async function passkeySetupSend(request: Request, env: Env): Promise<Resp
 // ── Verify email link → short-lived registration grant ────────────────────────
 
 export async function passkeySetupVerify(request: Request, env: Env): Promise<Response> {
-  const { token } = await request.json<{ token?: string }>();
+  let body: { token?: string } = {};
+  try {
+    body = await request.json<{ token?: string }>();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400, env);
+  }
+  const token = body.token?.trim();
   if (!token) return jsonResponse({ error: 'Missing token' }, 400, env);
 
   const data = await getAndDeletePasskeySetupLink(env, token);

--- a/worker/src/auth/passkey-setup.ts
+++ b/worker/src/auth/passkey-setup.ts
@@ -1,0 +1,87 @@
+import type { Env } from '../types.js';
+import { jsonResponse } from '../lib/http.js';
+import { generateRandomToken } from '../lib/encoding.js';
+import {
+  getUserIdByEmail,
+  upsertUserByEmail,
+  getAndDeletePasskeySetupLink,
+  putPasskeySetupLink,
+  putPasskeySetupGrant,
+} from '../lib/kv.js';
+import {
+  sendBrevoEmail,
+  requestOrigin,
+  buildPasskeySetupEmailHtml,
+} from '../lib/email.js';
+
+const SETUP_TTL_MS = 15 * 60 * 1_000;
+const GRANT_TTL_MS = 10 * 60 * 1_000;
+
+// ── Send confirmation email (new accounts only) ───────────────────────────────
+
+export async function passkeySetupSend(request: Request, env: Env): Promise<Response> {
+  const body  = await request.json<{ email?: string }>();
+  const email = body.email?.toLowerCase().trim();
+  if (!email || !email.includes('@')) return jsonResponse({ error: 'Invalid email' }, 400, env);
+
+  const existing = await getUserIdByEmail(env, email);
+  if (existing) {
+    return jsonResponse({
+      error:  'ACCOUNT_EXISTS',
+      detail: 'An account with this email already exists. Sign in, then add a passkey from your profile.',
+    }, 409, env);
+  }
+
+  const token = generateRandomToken();
+  await putPasskeySetupLink(env, token, { email, expires: Date.now() + SETUP_TTL_MS });
+
+  const origin   = requestOrigin(request, env);
+  const setupUrl = `${origin}/?passkey-setup=${token}`;
+
+  const result = await sendBrevoEmail({
+    apiKey:    env.BREVO_API_KEY,
+    to:        email,
+    fromEmail: env.EMAIL_FROM      || 'noreply@cardex.app',
+    fromName:  env.EMAIL_FROM_NAME || 'Cardex',
+    subject:   'Confirm your Cardex passkey registration',
+    html:      buildPasskeySetupEmailHtml(setupUrl),
+  });
+
+  if (!result.ok) {
+    console.error('Brevo error:', result.body);
+    return jsonResponse({ error: 'Failed to send email. Check BREVO_API_KEY.' }, 502, env);
+  }
+
+  return jsonResponse({ ok: true }, 200, env);
+}
+
+// ── Verify email link → short-lived registration grant ────────────────────────
+
+export async function passkeySetupVerify(request: Request, env: Env): Promise<Response> {
+  const { token } = await request.json<{ token?: string }>();
+  if (!token) return jsonResponse({ error: 'Missing token' }, 400, env);
+
+  const data = await getAndDeletePasskeySetupLink(env, token);
+  if (!data)                    return jsonResponse({ error: 'Link expired or already used' }, 401, env);
+  if (Date.now() > data.expires) return jsonResponse({ error: 'Link expired' }, 401, env);
+
+  // Re-check: account may have been created since the email was sent.
+  const existing = await getUserIdByEmail(env, data.email);
+  if (existing) {
+    return jsonResponse({
+      error:  'ACCOUNT_EXISTS',
+      detail: 'An account with this email already exists. Sign in, then add a passkey from your profile.',
+    }, 409, env);
+  }
+
+  const userId      = await upsertUserByEmail(env, data.email);
+  const setupToken  = generateRandomToken();
+
+  await putPasskeySetupGrant(env, setupToken, {
+    userId,
+    email:   data.email,
+    expires: Date.now() + GRANT_TTL_MS,
+  });
+
+  return jsonResponse({ setupToken, email: data.email }, 200, env);
+}

--- a/worker/src/auth/passkey.ts
+++ b/worker/src/auth/passkey.ts
@@ -1,10 +1,14 @@
 import type { Env, PasskeyMeta, User }  from '../types.js';
 import { jsonResponse }                 from '../lib/http.js';
 import { generateRandomToken, base64urlDecode, bufferToBase64url, concat } from '../lib/encoding.js';
-import { parseAttestationObject, parseAuthenticatorData, verifyCoseSignature, sha256 } from '../lib/cose.js';
+import {
+  parseAttestationObject, parseAuthenticatorData, verifyCoseSignature,
+  sha256, rpIdHash, bytesEqual,
+} from '../lib/cose.js';
+import { cborDecode } from '../lib/cbor.js';
 import {
   getAndDeleteChallenge, putChallenge, getCredential, putCredential, getUser, putUser,
-  upsertUserByEmail, deleteCredential,
+  deleteCredential, getPasskeySetupGrant, deletePasskeySetupGrant,
 } from '../lib/kv.js';
 import { issueToken, verifyToken }      from './jwt.js';
 
@@ -19,6 +23,16 @@ function verifyOrigin(origin: string, env: Env): boolean {
     'http://localhost:4173',
   ];
   return allowed.includes(origin);
+}
+
+async function verifyRpIdInAuthData(authDataBuf: Uint8Array, env: Env): Promise<boolean> {
+  const expected = await rpIdHash(getRpId(env));
+  return bytesEqual(authDataBuf.slice(0, 32), expected);
+}
+
+function isUserVerified(authDataBuf: Uint8Array): boolean {
+  const flags = authDataBuf[32] ?? 0;
+  return (flags & 0x04) !== 0;
 }
 
 async function recordPasskeyMeta(
@@ -58,13 +72,15 @@ async function ensurePasskeyMeta(
 
 /**
  * Start passkey registration.
- * - With `Authorization: Bearer <jwt>`: add a passkey to the signed-in account (no body).
- * - Without JWT: `{ email }` required — same email reuses one account (magic link + passkeys).
+ * - With `Authorization: Bearer <jwt>`: add a passkey to the signed-in account.
+ * - With `{ setupToken }`: after email-confirmed setup link (new account only).
+ * - Raw `{ email }` without proof is rejected (prevents account takeover).
  */
 export async function registerBegin(request: Request, env: Env): Promise<Response> {
-  let userId: string;
-  let email:  string;
-  let user:   User | null;
+  let userId:         string;
+  let email:          string;
+  let user:           User | null;
+  let registerSource: 'jwt' | 'setup';
 
   if (/^Bearer\s+\S/i.test(request.headers.get('Authorization') ?? '')) {
     const { userId: uid, error } = await verifyToken(request, env);
@@ -72,22 +88,72 @@ export async function registerBegin(request: Request, env: Env): Promise<Respons
     userId = uid;
     user   = await getUser(env, userId);
     if (!user) return jsonResponse({ error: 'User not found' }, 404, env);
-    email = user.email;
+    email          = user.email;
+    registerSource = 'jwt';
   } else {
-    let body: { email?: string } = {};
+    let body: { email?: string; setupToken?: string } = {};
     try {
-      body = await request.json<{ email?: string }>();
+      body = await request.json<{ email?: string; setupToken?: string }>();
     } catch { /* empty body */ }
-    const em = body.email?.toLowerCase().trim();
-    if (!em || !em.includes('@')) return jsonResponse({ error: 'Invalid email' }, 400, env);
-    email  = em;
-    userId = await upsertUserByEmail(env, email);
-    user   = await getUser(env, userId);
+
+    // Reject the old insecure path: email alone is never sufficient.
+    if (body.email && !body.setupToken) {
+      return jsonResponse({
+        error:  'EMAIL_CONFIRMATION_REQUIRED',
+        detail: 'Confirm your email first. Use the registration form to receive a confirmation link.',
+      }, 403, env);
+    }
+
+    const setupToken = body.setupToken?.trim();
+    if (!setupToken) {
+      return jsonResponse({
+        error:  'SETUP_TOKEN_REQUIRED',
+        detail: 'Email confirmation required before registering a passkey.',
+      }, 403, env);
+    }
+
+    const grant = await getPasskeySetupGrant(env, setupToken);
+    if (!grant)                    return jsonResponse({ error: 'Setup session expired' }, 401, env);
+    if (Date.now() > grant.expires) return jsonResponse({ error: 'Setup session expired' }, 401, env);
+
+    userId         = grant.userId;
+    email          = grant.email;
+    user           = await getUser(env, userId);
+    registerSource = 'setup';
+
+    const challenge = generateRandomToken();
+    await putChallenge(env, challenge, {
+      userId, email, type: 'register', registerSource, setupToken,
+    });
+
+    return jsonResponse({
+      options: {
+        challenge,
+        rp:   { name: 'Cardex Loyalty Wallet', id: getRpId(env) },
+        user: {
+          id:          userId,
+          name:        email,
+          displayName: user?.username ?? (email.split('@')[0] ?? email),
+        },
+        pubKeyCredParams: [
+          { alg: -7,   type: 'public-key' },
+          { alg: -257, type: 'public-key' },
+        ],
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          residentKey:             'required',
+          requireResidentKey:      true,
+          userVerification:        'required',
+        },
+        timeout:     60_000,
+        attestation: 'none',
+      },
+    }, 200, env);
   }
 
   const challenge = generateRandomToken();
 
-  await putChallenge(env, challenge, { userId, email, type: 'register' });
+  await putChallenge(env, challenge, { userId, email, type: 'register', registerSource });
 
   return jsonResponse({
     options: {
@@ -126,6 +192,10 @@ export async function registerFinish(request: Request, env: Env): Promise<Respon
   if (!challengeData || challengeData.type !== 'register')
     return jsonResponse({ error: 'Invalid or expired challenge' }, 400, env);
 
+  if (!challengeData.registerSource) {
+    return jsonResponse({ error: 'Registration not authorized' }, 403, env);
+  }
+
   const clientDataJSON = base64urlDecode(credential.response.clientDataJSON);
   const clientData     = JSON.parse(new TextDecoder().decode(clientDataJSON)) as {
     type: string; challenge: string; origin: string;
@@ -141,6 +211,26 @@ export async function registerFinish(request: Request, env: Env): Promise<Respon
 
   const credId = bufferToBase64url(authData.credentialId);
 
+  if (credId !== credential.id) {
+    return jsonResponse({ error: 'Credential id mismatch' }, 400, env);
+  }
+
+  const existing = await getCredential(env, credId);
+  if (existing) {
+    return jsonResponse({
+      error:  'PASSKEY_EXISTS',
+      detail: 'This passkey is already registered. Sign in with it, or add a new passkey from your profile while signed in.',
+    }, 409, env);
+  }
+
+  const attObj         = cborDecode(base64urlDecode(credential.response.attestationObject)) as Record<string, unknown>;
+  const attestationBuf = attObj['authData'] as Uint8Array;
+
+  if (!await verifyRpIdInAuthData(attestationBuf, env))
+    return jsonResponse({ error: 'RP ID mismatch' }, 400, env);
+  if (!isUserVerified(attestationBuf))
+    return jsonResponse({ error: 'User verification required' }, 400, env);
+
   const transports = credential.response.transports ?? [];
 
   await putCredential(env, credId, {
@@ -151,6 +241,10 @@ export async function registerFinish(request: Request, env: Env): Promise<Respon
   });
 
   await recordPasskeyMeta(env, challengeData.userId!, credId, transports);
+
+  if (challengeData.registerSource === 'setup' && challengeData.setupToken) {
+    await deletePasskeySetupGrant(env, challengeData.setupToken);
+  }
 
   const user  = await getUser(env, challengeData.userId!);
   const token = await issueToken(challengeData.userId!, env);
@@ -209,6 +303,11 @@ export async function loginFinish(request: Request, env: Env): Promise<Response>
 
   const authDataBuf = base64urlDecode(credential.response.authenticatorData);
   const authData    = parseAuthenticatorData(authDataBuf);
+
+  if (!await verifyRpIdInAuthData(authDataBuf, env))
+    return jsonResponse({ error: 'RP ID mismatch' }, 400, env);
+  if (!isUserVerified(authDataBuf))
+    return jsonResponse({ error: 'User verification required' }, 400, env);
 
   if (authData.counter > 0 && authData.counter <= credEntry.counter)
     return jsonResponse({ error: 'Counter replay detected' }, 400, env);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,7 +4,8 @@ import {
   registerBegin, registerFinish, loginBegin, loginFinish,
   listPasskeys, deletePasskey,
 } from './auth/passkey.js';
-import { magicSend, magicVerify }    from './auth/magic.js';
+import { passkeySetupSend, passkeySetupVerify } from './auth/passkey-setup.js';
+import { magicSend, magicVerify }               from './auth/magic.js';
 import { verifyToken }               from './auth/jwt.js';
 import { getCards, setCards }        from './cards.js';
 import { getUser }                   from './lib/kv.js';
@@ -31,6 +32,8 @@ export default {
       else if (pathname === '/auth/login/finish'    && request.method === 'POST') response = await loginFinish(request, env);
       else if (pathname === '/auth/passkeys'       && request.method === 'GET') response = await listPasskeys(request, env);
       else if (pathname === '/auth/passkeys'       && request.method === 'DELETE') response = await deletePasskey(request, env);
+      else if (pathname === '/auth/passkey/setup/send'   && request.method === 'POST') response = await passkeySetupSend(request, env);
+      else if (pathname === '/auth/passkey/setup/verify' && request.method === 'POST') response = await passkeySetupVerify(request, env);
 
       // ── Auth — magic link ───────────────────────────────────────────────────
       else if (pathname === '/auth/magic/send'   && request.method === 'POST') response = await magicSend(request, env);

--- a/worker/src/lib/cose.ts
+++ b/worker/src/lib/cose.ts
@@ -46,6 +46,8 @@ export function parseAttestationObject(buf: Uint8Array): AuthenticatorData {
 
 /**
  * Verify a COSE signature (ES256 or RS256).
+ * ES256: WebAuthn authenticators often emit ASN.1 DER signatures; Web Crypto
+ * expects IEEE P1363 (raw r||s). We try both encodings.
  */
 export async function verifyCoseSignature(
   coseKeyBytes: Uint8Array,
@@ -67,7 +69,15 @@ export async function verifyCoseSignature(
       false,
       ['verify'],
     );
-    return crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data);
+    const params = { name: 'ECDSA' as const, hash: 'SHA-256' as const };
+
+    if (await crypto.subtle.verify(params, key, signature, data)) return true;
+
+    const raw = ecdsaDerToRaw(signature, 32);
+    if (raw && raw.length === 64) {
+      return crypto.subtle.verify(params, key, raw, data);
+    }
+    return false;
   }
 
   // RSA-PKCS1v15 / RS256
@@ -89,6 +99,51 @@ export async function verifyCoseSignature(
 
 export async function sha256(data: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(await crypto.subtle.digest('SHA-256', data));
+}
+
+/** SHA-256 of the RP ID — must match the first 32 bytes of authenticatorData. */
+export async function rpIdHash(rpId: string): Promise<Uint8Array> {
+  return sha256(new TextEncoder().encode(rpId));
+}
+
+export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
+}
+
+/** Convert ASN.1 DER ECDSA signature to IEEE P1363 (r||s) for Web Crypto verify. */
+export function ecdsaDerToRaw(der: Uint8Array, fieldSize: number): Uint8Array | null {
+  try {
+    if (der[0] !== 0x30) return null;
+    let offset = 2;
+    if ((der[1]! & 0x80) !== 0) offset = 2 + (der[1]! & 0x7f);
+
+    const readInt = (): Uint8Array | null => {
+      if (der[offset] !== 0x02) return null;
+      const len = der[offset + 1]!;
+      const val = der.slice(offset + 2, offset + 2 + len);
+      offset += 2 + len;
+      return val;
+    };
+
+    const r = readInt();
+    const s = readInt();
+    if (!r || !s) return null;
+
+    const raw = new Uint8Array(fieldSize * 2);
+    const pad = (src: Uint8Array, dest: Uint8Array, destOff: number) => {
+      const trimmed = src[0] === 0x00 && src.length > fieldSize ? src.slice(1) : src;
+      const start   = destOff + fieldSize - trimmed.length;
+      dest.set(trimmed, start);
+    };
+    pad(r, raw, 0);
+    pad(s, raw, fieldSize);
+    return raw;
+  } catch {
+    return null;
+  }
 }
 
 // Re-export decode for use in passkey handler

--- a/worker/src/lib/email.ts
+++ b/worker/src/lib/email.ts
@@ -1,0 +1,70 @@
+import type { Env } from '../types.js';
+
+interface BrevoOptions {
+  apiKey:    string;
+  to:        string;
+  fromEmail: string;
+  fromName:  string;
+  subject:   string;
+  html:      string;
+}
+
+export async function sendBrevoEmail(opts: BrevoOptions): Promise<{ ok: boolean; body: string }> {
+  const res = await fetch('https://api.brevo.com/v3/smtp/email', {
+    method:  'POST',
+    headers: {
+      'api-key':      opts.apiKey,
+      'Content-Type': 'application/json',
+      'Accept':       'application/json',
+    },
+    body: JSON.stringify({
+      sender:      { email: opts.fromEmail, name: opts.fromName },
+      to:          [{ email: opts.to }],
+      subject:     opts.subject,
+      htmlContent: opts.html,
+    }),
+  });
+  return { ok: res.ok, body: await res.text() };
+}
+
+export function requestOrigin(request: Request, env: Env): string {
+  return request.headers.get('Origin') || env.FRONTEND_ORIGIN || 'https://vibecoded-stocard.pages.dev';
+}
+
+export function buildMagicEmailHtml(magicUrl: string): string {
+  return `
+    <div style="font-family:system-ui,sans-serif;max-width:480px;margin:0 auto;padding:32px 24px;background:#f9f9fb;border-radius:12px">
+      <h1 style="font-size:24px;font-weight:700;margin:0 0 8px;color:#0a0a0f">Sign in to Cardex</h1>
+      <p style="color:#555;margin:0 0 28px;line-height:1.6">
+        Click the button below to sign in. This link expires in <strong>15 minutes</strong> and can only be used once.
+      </p>
+      <a href="${magicUrl}"
+         style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#7c6dfa,#fa6d9a);color:white;text-decoration:none;border-radius:10px;font-weight:600;font-size:16px">
+        Sign in to Cardex
+      </a>
+      <p style="color:#999;font-size:12px;margin:28px 0 0;line-height:1.6">
+        If you didn't request this, you can safely ignore this email.<br/>
+        Or copy this link:<br/>
+        <a href="${magicUrl}" style="color:#7c6dfa;word-break:break-all">${magicUrl}</a>
+      </p>
+    </div>`;
+}
+
+export function buildPasskeySetupEmailHtml(setupUrl: string): string {
+  return `
+    <div style="font-family:system-ui,sans-serif;max-width:480px;margin:0 auto;padding:32px 24px;background:#f9f9fb;border-radius:12px">
+      <h1 style="font-size:24px;font-weight:700;margin:0 0 8px;color:#0a0a0f">Confirm your Cardex account</h1>
+      <p style="color:#555;margin:0 0 28px;line-height:1.6">
+        Click below to verify your email and register a passkey. This link expires in <strong>15 minutes</strong> and can only be used once.
+      </p>
+      <a href="${setupUrl}"
+         style="display:inline-block;padding:14px 28px;background:linear-gradient(135deg,#7c6dfa,#fa6d9a);color:white;text-decoration:none;border-radius:10px;font-weight:600;font-size:16px">
+        Verify &amp; register passkey
+      </a>
+      <p style="color:#999;font-size:12px;margin:28px 0 0;line-height:1.6">
+        If you didn't request this, you can safely ignore this email.<br/>
+        Or copy this link:<br/>
+        <a href="${setupUrl}" style="color:#7c6dfa;word-break:break-all">${setupUrl}</a>
+      </p>
+    </div>`;
+}

--- a/worker/src/lib/email.ts
+++ b/worker/src/lib/email.ts
@@ -1,4 +1,5 @@
 import type { Env } from '../types.js';
+import { allowedOrigins } from './http.js';
 
 interface BrevoOptions {
   apiKey:    string;
@@ -28,7 +29,10 @@ export async function sendBrevoEmail(opts: BrevoOptions): Promise<{ ok: boolean;
 }
 
 export function requestOrigin(request: Request, env: Env): string {
-  return request.headers.get('Origin') || env.FRONTEND_ORIGIN || 'https://vibecoded-stocard.pages.dev';
+  const origin  = request.headers.get('Origin');
+  const allowed = allowedOrigins(env);
+  if (origin && allowed.includes(origin)) return origin;
+  return env.FRONTEND_ORIGIN || 'https://vibecoded-stocard.pages.dev';
 }
 
 export function buildMagicEmailHtml(magicUrl: string): string {

--- a/worker/src/lib/kv.ts
+++ b/worker/src/lib/kv.ts
@@ -1,4 +1,7 @@
-import type { Env, User, Credential, ChallengeData, MagicLinkData, Card, Tombstone } from '../types.js';
+import type {
+  Env, User, Credential, ChallengeData, MagicLinkData,
+  PasskeySetupLinkData, PasskeySetupGrantData, Card, Tombstone,
+} from '../types.js';
 
 // ── User ─────────────────────────────────────────────────────────────────────
 
@@ -50,6 +53,38 @@ export async function getAndDeleteMagicLink(
 ): Promise<MagicLinkData | null> {
   const data = await env.CARDEX_KV.get<MagicLinkData>(`magiclink:${token}`, 'json');
   if (data) await env.CARDEX_KV.delete(`magiclink:${token}`);
+  return data;
+}
+
+// ── Passkey setup (email-confirmed registration) ────────────────────────────
+
+export const putPasskeySetupLink = (env: Env, token: string, data: PasskeySetupLinkData) =>
+  env.CARDEX_KV.put(`passkeysetup:${token}`, JSON.stringify(data), { expirationTtl: 900 });
+
+export async function getAndDeletePasskeySetupLink(
+  env:   Env,
+  token: string,
+): Promise<PasskeySetupLinkData | null> {
+  const data = await env.CARDEX_KV.get<PasskeySetupLinkData>(`passkeysetup:${token}`, 'json');
+  if (data) await env.CARDEX_KV.delete(`passkeysetup:${token}`);
+  return data;
+}
+
+export const putPasskeySetupGrant = (env: Env, token: string, data: PasskeySetupGrantData) =>
+  env.CARDEX_KV.put(`passkeygrant:${token}`, JSON.stringify(data), { expirationTtl: 600 });
+
+export const getPasskeySetupGrant = (env: Env, token: string) =>
+  env.CARDEX_KV.get<PasskeySetupGrantData>(`passkeygrant:${token}`, 'json');
+
+export const deletePasskeySetupGrant = (env: Env, token: string) =>
+  env.CARDEX_KV.delete(`passkeygrant:${token}`);
+
+export async function getAndDeletePasskeySetupGrant(
+  env:   Env,
+  token: string,
+): Promise<PasskeySetupGrantData | null> {
+  const data = await env.CARDEX_KV.get<PasskeySetupGrantData>(`passkeygrant:${token}`, 'json');
+  if (data) await env.CARDEX_KV.delete(`passkeygrant:${token}`);
   return data;
 }
 

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -27,6 +27,23 @@ export interface ChallengeData {
   userId?: string;
   email?:  string;
   type:    'register' | 'login';
+  /** Registration authorized via JWT (add passkey) or email setup token (new account). */
+  registerSource?: 'jwt' | 'setup';
+  /** Setup grant token — consumed when registration finishes successfully. */
+  setupToken?: string;
+}
+
+/** Email link for first-time passkey registration (?passkey-setup=). */
+export interface PasskeySetupLinkData {
+  email:   string;
+  expires: number;
+}
+
+/** Short-lived grant after setup link verify — required for register/begin without JWT. */
+export interface PasskeySetupGrantData {
+  userId:  string;
+  email:   string;
+  expires: number;
 }
 
 export interface MagicLinkData {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a critical account-takeover vulnerability in passkey registration and hardens WebAuthn verification (including iOS PWA signature failures).

### Security fix (account takeover)

**Before:** Entering any existing email on "Create account" → `upsertUserByEmail` mapped to the victim's account → completing WebAuthn on the attacker's device immediately issued a JWT with no email proof.

**After:**
- `POST /auth/register/begin` **rejects** raw `{ email }` without proof
- **Existing emails** on the registration form get `409 ACCOUNT_EXISTS` — user is directed to sign in and manage passkeys from their profile
- **New accounts** must confirm email first via `POST /auth/passkey/setup/send` → `/?passkey-setup=TOKEN` → short-lived `setupToken` → passkey registration
- **Logged-in users** can still add passkeys via JWT (unchanged)
- **Existing credentials cannot be overwritten** (`409 PASSKEY_EXISTS`)

### iOS PWA / WebAuthn hardening

- ES256 signature verification now tries IEEE P1363 and ASN.1 DER encodings (fixes "Signature verification failed" on some iOS WebKit paths)
- Server now verifies `rpIdHash` and user-verification (UV) flag
- Passkey-setup links use the same resilient verify + retry pattern as magic links (keeps `?passkey-setup=` in URL on transient failures for Safari/PWA handoff)

### Passkey management

List/revoke was already implemented in the account sheet — copy updated to highlight reviewing/removing unrecognized passkeys.

## Test plan

- [ ] Try registering with an **existing** email → should show "account exists, sign in first" (no instant login)
- [ ] Register with a **new** email → confirmation email → link opens → passkey prompt → signed in
- [ ] While signed in → Account → add passkey on this device
- [ ] While signed in → Account → list and remove passkeys
- [ ] Passkey login on iOS PWA (after adding passkey from PWA or Safari profile flow)
- [ ] Magic link sign-in still works (`?magic=`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f42ef-d1d4-7ded-9d0b-2b0343aba5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f42ef-d1d4-7ded-9d0b-2b0343aba5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-step passkey registration flow that emails a confirmation link and completes registration from it.
  * Added support for passkey setup links in the app, including confirming and clearing the setup token from the URL.
* **Bug Fixes**
  * Improved passkey verification with clearer outcomes, resilient retries for transient failures, and stronger authenticator validation.
  * Added protections against duplicate passkey registrations and improved login error messaging.
* **Documentation**
  * Updated registration and passkey on-screen instructions to guide account creation and managing unrecognized passkeys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->