### PR TITLE
chore(ci): bump GitHub Actions to Node 24-native versions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Process Dependabot PRs
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
 
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Deploy Worker (production)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch full history so we can resolve which branch the tag is on
           fetch-depth: 0
@@ -32,7 +32,7 @@ jobs:
         run: npm run type-check
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken:         ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId:        ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -44,7 +44,7 @@ jobs:
     name: Deploy Frontend (production)
     needs: deploy-worker-production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
@@ -69,7 +69,7 @@ jobs:
         run: npm ci
 
       - name: Deploy to Cloudflare Pages (production)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -77,6 +77,6 @@ jobs:
           command:   pages deploy ../dist --project-name=vibecoded-stocard --branch=main
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Deploy Worker (staging)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
@@ -29,7 +29,7 @@ jobs:
         run: npm run type-check
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken:         ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId:        ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -42,7 +42,7 @@ jobs:
     name: Deploy Frontend (staging)
     needs: deploy-worker-staging
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
@@ -64,7 +64,7 @@ jobs:
         run: npm ci
 
       - name: Deploy to Cloudflare Pages (staging)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Silences the Node 20 deprecation warnings in CI by bumping actions to versions that run on **Node 24** natively.

## Changes

| Action | Before | After | Notes |
|--------|--------|-------|-------|
| `actions/checkout` | v6 | **v7** | `node24` runtime |
| `actions/setup-node` | v6 | v6 | Already latest major; v6.4.0 uses `node24` — no v7 exists |
| `cloudflare/wrangler-action` | v3 | **v4** | `node24` runtime |
| `softprops/action-gh-release` | v2 | **v3** | `node24` runtime |
| `actions/github-script` | v8 | **v9** | `node24` runtime (dependabot workflow) |

The deprecation notice was informational — GitHub was already forcing Node 24 for actions still declared as `node20`. These newer action versions declare `node24` explicitly, so the warning goes away.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43ca-29be-7fea-ae70-12c838f0f361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43ca-29be-7fea-ae70-12c838f0f361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

