### PR TITLE
Disable Wrangler autoconfig PRs for Pages+Worker architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           apiToken:         ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId:        ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: worker
-          command:          deploy   # default env = production
+          command:          deploy --autoconfig=false   # default env = production
 
   deploy-frontend-production:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -37,7 +37,7 @@ jobs:
           accountId:        ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: worker
           # Deploys to a staging environment defined in wrangler.toml
-          command:          deploy --env staging
+          command:          deploy --env staging --autoconfig=false
 
   deploy-frontend-staging:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/worker/package.json
+++ b/worker/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --autoconfig=false",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+# Cardex deploys the frontend via Cloudflare Pages and the API via worker/wrangler.toml.
+# This file exists only to prevent Wrangler autoconfig from opening configuration PRs
+# when Workers Builds scans the repo root (Vite frontend with no Worker entry point).
+# Production deploys run through GitHub Actions — do not `wrangler deploy` from here.
+name = "cardex"
+compatibility_date = "2024-01-01"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Wrangler autoconfig (now GA) was opening automatic configuration PRs in this repo. Cardex uses **Cloudflare Pages** for the Vite frontend and a separate **Worker** in `worker/` for the API — autoconfig incorrectly tries to migrate the frontend to Workers.

## Solution

1. **Root `wrangler.toml` sentinel** — Workers Builds only opens autoconfig PRs when no Wrangler config exists at the build root. A minimal config at the repo root tells Wrangler the project is already configured, without adding a deployable Worker entry point.

2. **`--autoconfig=false` on worker deploys** — Explicit opt-out on CI deploy commands and `worker/package.json` as defense in depth.

## Notes

- Production deploys are unchanged (GitHub Actions → `wrangler pages deploy` for frontend, `wrangler deploy` from `worker/` for API).
- If a Cloudflare Worker build is connected to this repo with root directory `/`, consider setting its **root directory** to `worker/` in the dashboard, or changing its deploy command to include `--autoconfig=false`.
- You can close/ignore any existing open autoconfig PRs without merging them.

Fixes the issue discussed in [workers-sdk#11667](https://github.com/cloudflare/workers-sdk/discussions/11667#discussioncomment-17157719).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4cb9-e771-7454-b9a0-56ecb6def86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4cb9-e771-7454-b9a0-56ecb6def86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Improved staging and production deployment consistency by using fixed Wrangler configuration settings.
  * Added safeguards to prevent unintended configuration changes during automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->